### PR TITLE
feat: add minimumReleaseAge to pnpm-workspace.yaml for supply chain protection

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,7 @@ publicHoistPattern:
 
 # pinバージョンでインストールする
 savePrefix: ''
+
+# 公開から3日未満のバージョンをインストールしない（サプライチェーン攻撃対策）
+# https://pnpm.io/settings#minimumreleaseage
+minimumReleaseAge: 4320


### PR DESCRIPTION
## Summary

axios サプライチェーン攻撃（2026-03-30）を受けて、pnpm のインストール時にパッケージの最小リリース経過時間を設定する。

- `pnpm-workspace.yaml` に `minimumReleaseAge: 4320`（3日 = 4320分）を追加
- 公開から3日未満のバージョンは自動的にスキップされ、条件を満たす最新バージョンにフォールバック
- Renovate 側の `minimumReleaseAge` と合わせて二重防御

### 挙動（`savePrefix: ''` の pin バージョン運用前提）

| 状況 | 挙動 |
|---|---|
| `pnpm add axios`（latest が3日未満） | 3日以上経過した最新バージョンに**サイレントにフォールバック** |
| `pnpm add axios@1.14.1`（明示的に3日未満を指定） | **エラーで停止**。`minimumReleaseAgeExclude` への追加を案内 |
| `pnpm add brand-new-pkg`（全バージョンが3日未満） | **エラーで停止**。フォールバック先がない |

### 参考

- [pnpm minimumReleaseAge ドキュメント](https://pnpm.io/settings#minimumreleaseage)
- [pnpm/pnpm#9921 - Enforce minimum package age policy](https://github.com/pnpm/pnpm/issues/9921)
- [pnpm/pnpm#9987 - latest タグのフォールバック実装](https://github.com/pnpm/pnpm/issues/9987)
- [axios supply chain attack (2026-03-30)](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan)

## Test plan

- [ ] `pnpm install --frozen-lockfile` が正常に完了することを確認