### PR TITLE
chore(pnpm): add reporter append-only setting

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,3 +21,6 @@ savePrefix: ''
 # NOTE: transitive dependency の再解決時にフォールバックが効かない pnpm のバグにより一時無効化
 # https://github.com/pnpm/pnpm/issues/11068
 # minimumReleaseAge: 4320
+
+# ログ出力形式をカスタマイズ
+reporter: append-only


### PR DESCRIPTION
## 概要

- `pnpm-workspace.yaml` に `reporter: append-only` を追加
- CI やターミナルマルチプレクサ環境でのログ出力を最適化する
