### PR TITLE
chore: remove CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-# CLAUDE.md
-
-このリポジトリで Claude Code (claude.ai/code) が作業する際のガイドラインです。
-
-## リリース・Conventional Commits
-
-- `BREAKING CHANGE:` フッターと `feat!:` / `fix!:` の `!` 修飾は、**リリースされるパッケージ・公開アセットの互換性を破る変更にのみ**使用する。CI / workflows / branch protection / リポジトリ運用上の変更には使わない。これらの注意事項は PR 本文に記述する（release-please など自動リリースツールが major / minor バンプを誤って行い、CHANGELOG に `⚠ BREAKING CHANGES` セクションを誤生成するのを防ぐため。実例: 2026-04-25 にこのリポジトリ群で `chore: migrate reusable workflows to v3.0.0` PR が誤って BREAKING CHANGE として記録された）。


### PR DESCRIPTION
## なぜ

このリポジトリのエージェント向けガイドラインは AGENTS.md 系の共通フォーマットに集約しており、`CLAUDE.md` を単独で持ち続ける必要がなくなったため削除する。

## 何を

- `CLAUDE.md` を削除

## 影響

- リリースされるパッケージ・公開アセットへの影響なし（リポジトリ運用上のドキュメント整理）