### PR TITLE
chore: add readme with profile header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# .github
+
+<!-- Main Image -->
+<br>
+<div align="center">
+  <img src="https://github.githubassets.com/assets/profile-joined-github-456737b47749.svg" alt="github" width="480" />
+</div>
+<p align="center" class="color-fg-success">@nozomiishii</p>
+<br>


### PR DESCRIPTION
## Summary

- リポジトリトップ用の README を追加
- GitHub プロフィール画像と @nozomiishii の表示を中央揃えで配置

## Test plan

- [ ] GitHub 上で README の表示を確認