### PR TITLE
chore: use h2 for profile handle in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 <div align="center">
   <img src="https://github.githubassets.com/assets/profile-joined-github-456737b47749.svg" alt="github" width="480" />
 </div>
-<p align="center" class="color-fg-success">@nozomiishii</p>
+<h2 align="center">@nozomiishii</h2>
 <br>


### PR DESCRIPTION
## Summary

- README の @nozomiishii 表示を `<p>` から `<h2>` に変更（#791 のフォローアップ）

## Test plan

- [ ] GitHub 上で README の見出し表示を確認