### PR TITLE
fix: change username h2 tag to p tag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 <div align="center">
   <img src="https://github.githubassets.com/assets/profile-joined-github-456737b47749.svg" alt="github" width="480" />
 </div>
-<h2 align="center">@nozomiishii</h2>
+<p align="center">@nozomiishii</p>
 <br>


### PR DESCRIPTION
## 概要

- READMEの `@nozomiishii` 表示を `h2` タグから `p` タグに変更しました。
- 中央寄せの表示はそのまま維持しています。

## 確認

- pre-commit の textlint が通過しました。
- commit-msg の commitlint が通過しました。