### PR TITLE
chore: adopt .hooks/ and Codex SessionStart hook

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          { "type": "command", "command": "bash \"$(git rev-parse --show-toplevel)/.hooks/startup.sh\"" }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 概要

dotfiles の `.hooks/` 化＋Codex hook 配線（[#1150](https://github.com/nozomiishii/dotfiles/pull/1150)）を本 repo に展開する。本 repo は CLAUDE.md を持たないので AGENTS.md 化（[#1149](https://github.com/nozomiishii/dotfiles/pull/1149)）は対象外。

## 変更点

- `.claude/hooks/startup.sh` を `.hooks/startup.sh` に移動。先頭で repo root へ `cd`
- `.codex/hooks.json` を新規作成、Codex の SessionStart で同じ startup.sh を呼ぶ