### PR TITLE
chore: move pull-request permission to job level for revert support

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -14,4 +14,4 @@ permissions:
 
 jobs:
   github-actions:
-    uses: nozomiishii/workflows/.github/workflows/github-actions.yaml@bdea1e0028e1f3c1ba9411f8024c1b247d0bfff7 # v3.1.2
+    uses: nozomiishii/workflows/.github/workflows/github-actions.yaml@0bff52c601e5f02549aef27a2f9d6e39c06e563e # v3.2.0

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   pull-request:
-    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@bdea1e0028e1f3c1ba9411f8024c1b247d0bfff7 # v3.1.2
+    uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@0bff52c601e5f02549aef27a2f9d6e39c06e563e # v3.2.0

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -7,9 +7,10 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
+permissions: {}
 
 jobs:
   pull-request:
+    permissions:
+      pull-requests: write  # write: format revert PR titles, read: validate PR titles
     uses: nozomiishii/workflows/.github/workflows/pull-request.yaml@0bff52c601e5f02549aef27a2f9d6e39c06e563e # v3.2.0

--- a/.github/workflows/_secret-scan.yaml
+++ b/.github/workflows/_secret-scan.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   secret-scan:
-    uses: nozomiishii/workflows/.github/workflows/secret-scan.yaml@bdea1e0028e1f3c1ba9411f8024c1b247d0bfff7 # v3.1.2
+    uses: nozomiishii/workflows/.github/workflows/secret-scan.yaml@0bff52c601e5f02549aef27a2f9d6e39c06e563e # v3.2.0


### PR DESCRIPTION
pull-request reusable workflow が revert PR タイトルの自動変換で pull-requests: write を必要とするようになったため、job レベルに permission を移動。関連: https://github.com/nozomiishii/workflows/pull/71