### PR TITLE
chore: migrate commitlint config to commitlint.config.ts

### DIFF
--- a/.github/workflows/create-issue.yaml
+++ b/.github/workflows/create-issue.yaml
@@ -2,7 +2,7 @@ name: create issue
 
 on:
   schedule:
-    - cron: '0 0 1 1,4,7,10 *'
+    - cron: "0 0 1 1,4,7,10 *"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -15,8 +15,8 @@ jobs:
     name: create issue
     runs-on: ubuntu-slim
     permissions:
-      contents: read  # required by actions/checkout and create-an-issue to read the template file
-      issues: write  # required by JasonEtco/create-an-issue to create the issue
+      contents: read # required by actions/checkout and create-an-issue to read the template file
+      issues: write # required by JasonEtco/create-an-issue to create the issue
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,1 +1,1 @@
-module.exports = require('@nozomiishii/markdownlint-cli2-config');
+module.exports = require("@nozomiishii/markdownlint-cli2-config");

--- a/.textlintrc.yaml
+++ b/.textlintrc.yaml
@@ -1,6 +1,6 @@
 plugins:
   # mdxにもlintを適用できる(@textlint/markdownはBuilt-inサポートされてる)　https://github.com/textlint/textlint/tree/master/packages/@textlint/textlint-plugin-markdown
-  '@textlint/markdown':
+  "@textlint/markdown":
     extensions:
       - .mdx
 
@@ -9,7 +9,7 @@ rules:
   terminology: true
 
   # 同一ファイル内の文章で同義語の表記ゆれがないか https://github.com/textlint-ja/textlint-rule-no-synonyms
-  '@textlint-ja/no-synonyms': true
+  "@textlint-ja/no-synonyms": true
 
   # 1文の長さは100文字以下 https://github.com/textlint-rule/textlint-rule-sentence-length
   # sentence-length:

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,1 +1,0 @@
-module.exports = { extends: ['@nozomiishii'] };

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,1 @@
+export default { extends: ["@nozomiishii/commitlint-config"] };

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -16,13 +16,13 @@ pre-commit:
 
   jobs:
     - name: lint-textlint
-      glob: '*.md'
+      glob: "*.md"
       run: pnpm exec textlint {staged_files}
 
     - name: generate-pdf-cv
-      glob: 'src/cv/nozomi_ishii_CV.md'
+      glob: "src/cv/nozomi_ishii_CV.md"
       run: pnpm run pdf:cv src/cv/nozomi_ishii_CV.md && git add src/cv/nozomi_ishii_CV.pdf
 
     - name: generate-pdf-pay
-      glob: 'src/pay/pay-ja.md'
+      glob: "src/pay/pay-ja.md"
       run: pnpm run pdf:pay src/pay/pay-ja.md && git add src/pay/pay-ja.pdf

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,1 +1,1 @@
-export { default } from '@nozomiishii/prettier-config';
+export { default } from "@nozomiishii/prettier-config";


### PR DESCRIPTION
## 概要

[PR #881](https://github.com/nozomiishii/.github/pull/881) の `recommended / required` チェックが、リポジトリルートに `commitlint.config.ts` が無いため失敗している。workflows v4.3.0 の recommended workflow は `commitlint.config.ts` を要求する。

## 変更内容

- `commitlint.config.cjs` を削除し、`commitlint.config.ts` に置き換え
  - 内容は configs など他リポジトリと同じ `export default { extends: ["@nozomiishii/commitlint-config"] };`
- prettier-config 2.2.0 のスタイル変更で違反になっていた 5 ファイルを `pnpm format:fix` で修正

## 確認

- `nozo-commitlint --config commitlint.config.ts` で正常メッセージが通過し、不正メッセージが reject されることを確認
- lefthook の commit-msg フックも新設定で通過
- `pnpm format` が全ファイル通過