### PR TITLE
chore: convert markdownlint-cli2 config to esm

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -1,1 +1,0 @@
-module.exports = require("@nozomiishii/markdownlint-cli2-config");

--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -1,0 +1,1 @@
+export { default } from "@nozomiishii/markdownlint-cli2-config";


### PR DESCRIPTION
## 概要

リポジトリ内で唯一 CommonJS で書かれていた `.markdownlint-cli2.cjs` を ESM (`.markdownlint-cli2.mjs`) に変更する。dotfiles・configs・renovate は既に `.mjs` 化済みで、`@nozomiishii/markdownlint-cli2-config` の setup スクリプトも `.mjs` を生成する。

## 共有 config が読み込まれていない不具合の修正

`@nozomiishii/markdownlint-cli2-config` は `"type": "module"` の純 ESM パッケージ。CJS から `require()` すると module namespace が返るため、設定の shape が壊れていた。

```
require('@nozomiishii/markdownlint-cli2-config')
// => { __esModule: true, default: { config, ignores, ... } }
```

markdownlint-cli2 は top-level の `config` / `ignores` を見るため、共有 config が一切適用されていなかった。

| 設定 | Finding | Linting | Summary |
| --- | --- | --- | --- |
| `.cjs` (変更前) | `**/*.md` | 3415 files | 105459 issues |
| `.mjs` (変更後) | `**/*.md !node_modules !**/node_modules !**/submodules !LICENSE !.git` | 5 files | 4 issues |

## 確認

- `.mjs` で共有 config の ignore パターンと rule が適用されることを確認
- `prettier --check` 通過
- ファイル名を直接参照している箇所は無し (lefthook・workflow・npm scripts いずれも参照なし)

## 補足

変更後に残る 4 件の指摘 (`src/pay/pay-ja.md` の MD022 / MD032) は、これまで共有 config が効いていなかったために顕在化していなかった既存の違反。markdownlint-cli2 は現状 npm script にも lefthook にも CI にも組み込まれていないため、この PR では手を付けていない。